### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -312,7 +312,7 @@ export function setText(htmlControl, tagName, updatedStr, shouldAppendBr) {
     let innerHtml = getCleanHtmlForAtlassian(updatedStr);
     $(htmlControl).html(innerHtml);
   } else {
-    $(htmlControl).html(updatedStr);
+    $(htmlControl).html(escapeHtml(updatedStr));
   }
 
   setEndOfContenteditable(htmlControl);
@@ -404,6 +404,18 @@ export function getUpdatedString(text, matchedWord, correctedWord) {
   }
 
   return text;
+}
+
+
+// Escape HTML metacharacters to prevent XSS.
+export function escapeHtml(str) {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 export function getCapitalisedContentForI(text) {


### PR DESCRIPTION
Potential fix for [https://github.com/hrai/auto-capitalise-sentence/security/code-scanning/5](https://github.com/hrai/auto-capitalise-sentence/security/code-scanning/5)

To fix this vulnerability, user-controlled values must never be directly set as HTML. Instead, they should be safely escaped to neutralize any HTML metacharacters before rendering. For the generic (non-Atlassian) branch at line 315, before passing `updatedStr` to `.html()`, it should be escaped so that all the HTML metacharacters (`<`, `>`, `&`, `"`, `'`) are replaced with their corresponding entities.

The best fix is:  
- Add a dedicated function (e.g. `escapeHtml`) to convert unsafe characters to their HTML entity equivalents.
- Use this `escapeHtml` function to sanitize `updatedStr` before setting it with `$(htmlControl).html()` in the else branch on line 315.
- Ensure that the Atlassian custom clean function is left untouched (since it may have its own rules and context), and only generic handling for other hosts is sanitized.
- Add the `escapeHtml` function definition in the same file, preferably near the other utility exports.

No dependencies are needed; escaping can be implemented in a few lines using standard logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
