### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -491,6 +491,12 @@ export function getNbspCount(text) {
   return (text.match(new RegExp(nbsp, 'g')) || []).length;
 }
 
+// Returns true if host is exactly 'atlassian.net' or is a direct subdomain like 'foo.atlassian.net'
+function isAtlassianCloudHost(host) {
+  // Only accept hosts that are exactly 'atlassian.net' or end with '.atlassian.net', but are not like 'foo.bar.atlassian.net.evil.com'
+  return host === 'atlassian.net' || (/^[a-zA-Z0-9-]+\.atlassian\.net$/i).test(host);
+}
+
 export function setText(htmlControl, tagName, updatedStr, shouldAppendBr) {
   //console.log("setting text: "+ updatedStr);
   //debugger
@@ -512,7 +518,7 @@ export function setText(htmlControl, tagName, updatedStr, shouldAppendBr) {
   }
 
   //fix for confluence and jira user tags
-  if (window.location.host.includes('atlassian.net')) {
+  if (isAtlassianCloudHost(window.location.host)) {
     const innerHtml = getCleanHtmlForAtlassian(updatedStr);
     // Security: updatedStr comes from getText which reads innerHTML, so it preserves
     // whatever HTML the browser already rendered when the user typed it.


### PR DESCRIPTION
Potential fix for [https://github.com/hrai/auto-capitalise-sentence/security/code-scanning/6](https://github.com/hrai/auto-capitalise-sentence/security/code-scanning/6)

**General fix:**  
Rather than using a substring match for `'atlassian.net'`, the host portion of the URL should be parsed and compared exactly to a whitelist of known legitimate Atlassian cloud host patterns. For Atlassian cloud, all recognized product sites are on subdomains of `atlassian.net` (e.g., `company.atlassian.net`). The correct check is to verify that `window.location.host` either equals `atlassian.net` or is of the form `<subdomain>.atlassian.net`.

**Detailed fix:**  
Replace the `window.location.host.includes('atlassian.net')` check with a function that returns `true` only if the host is exactly `atlassian.net` or ends with `.atlassian.net` and has at least one subdomain directly before it (for example, using a regex or string comparison). This code should be local to the affected check (`setText` function), and a helper function may be introduced.

**Required changes in `src/utils.js` around `setText`:**
- Insert helper function `isAtlassianCloudHost(host)` before `setText`.
- Replace `window.location.host.includes('atlassian.net')` with `isAtlassianCloudHost(window.location.host)`.

No new external libraries are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
